### PR TITLE
Fix load archive button behavior

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -154,6 +154,9 @@ class MainWindow(QMainWindow):
         if not file_path:
             return
 
+        # notify user about chosen archive path
+        QMessageBox.information(self, "Выбран архив", file_path)
+
         dest = EXTRACTED_FILES_DIR / Path(file_path).stem
         self.archive_worker = ArchiveExtractWorker(file_path, dest)
         self.archive_worker.finished.connect(self.on_archive_extracted)


### PR DESCRIPTION
## Summary
- show message with the selected archive path when loading an archive

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c08cd81d48332898480fbf64a00b3