### PR TITLE
Fix config import in main_window

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,6 +1,13 @@
 """Main application window."""
 
 from pathlib import Path
+import sys
+
+# Ensure the project root is in sys.path so that config can be imported even
+# when running this module directly from the ``src/ui`` directory.
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (


### PR DESCRIPTION
## Summary
- allow importing `config.py` when `main_window` is run directly

## Testing
- `python -m py_compile src/ui/main_window.py`
- `python -m compileall -q src`
- `python src/ui/main_window.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_683c0ce61480833285166d863a2b62ad