### PR TITLE
Add file preview and better metadata error messages

### DIFF
--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -72,6 +72,7 @@ class ArchiveExtractWorker(QThread):
 
 
 from services.file_metadata import extract_metadata
+from services.file_preview import extract_preview_text
 
 
 class FileMetadataWorker(QThread):
@@ -87,3 +88,21 @@ class FileMetadataWorker(QThread):
         for path in self.files:
             count, language, paper = extract_metadata(Path(path))
             self.result.emit(path, language, paper, count)
+
+
+class FilePreviewWorker(QThread):
+    """Worker thread for extracting file preview text."""
+
+    finished = pyqtSignal(str, str)  # path, preview text
+    error = pyqtSignal(str, str)  # path, error message
+
+    def __init__(self, path: str):
+        super().__init__()
+        self.path = path
+
+    def run(self) -> None:
+        try:
+            text = extract_preview_text(Path(self.path))
+            self.finished.emit(self.path, text)
+        except Exception as exc:
+            self.error.emit(self.path, str(exc))

--- a/src/services/file_metadata.py
+++ b/src/services/file_metadata.py
@@ -47,8 +47,9 @@ def _pdf_metadata(path: Path) -> Tuple[str, str, str]:
         mm_height = height_pt * 0.3527778
         paper = _paper_format_from_dimensions(mm_width, mm_height)
         return str(num_pages), language, paper
-    except Exception:
-        return "-", "-", "-"
+    except Exception as exc:
+        err = f"Ошибка: {exc}"
+        return err, err, err
 
 
 def _docx_metadata(path: Path) -> Tuple[str, str, str]:
@@ -66,8 +67,9 @@ def _docx_metadata(path: Path) -> Tuple[str, str, str]:
         except Exception:
             paper = "-"
         return count, language, paper
-    except Exception:
-        return "-", "-", "-"
+    except Exception as exc:
+        err = f"Ошибка: {exc}"
+        return err, err, err
 
 
 def _text_metadata(path: Path) -> Tuple[str, str, str]:
@@ -77,8 +79,9 @@ def _text_metadata(path: Path) -> Tuple[str, str, str]:
         text_sample = " ".join(lines[:50])
         language = _detect_lang(text_sample)
         return str(len(lines)), language, "-"
-    except Exception:
-        return "-", "-", "-"
+    except Exception as exc:
+        err = f"Ошибка: {exc}"
+        return err, err, err
 
 
 def extract_metadata(path: Path) -> Tuple[str, str, str]:
@@ -89,5 +92,6 @@ def extract_metadata(path: Path) -> Tuple[str, str, str]:
         return _docx_metadata(path)
     if ext in {".txt", ".csv"}:
         return _text_metadata(path)
-    return "-", "-", "-"
+    msg = "Неподдерживаемый формат"
+    return msg, msg, msg
 

--- a/src/services/file_preview.py
+++ b/src/services/file_preview.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PyPDF2 import PdfReader
+from docx import Document
+from PIL import Image
+import pytesseract
+
+
+def _pdf_preview(path: Path) -> str:
+    reader = PdfReader(str(path))
+    text = ""
+    for page in reader.pages[:2]:
+        t = page.extract_text() or ""
+        text += t
+        if len(text) >= 2000:
+            text = text[:2000]
+            break
+    return text.strip()
+
+
+def _docx_preview(path: Path) -> str:
+    doc = Document(str(path))
+    text = ""
+    for para in doc.paragraphs:
+        text += para.text + "\n"
+        if len(text) >= 2000:
+            text = text[:2000]
+            break
+    return text.strip()
+
+
+def _text_preview(path: Path) -> str:
+    lines: list[str] = []
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            for _ in range(50):
+                line = f.readline()
+                if not line:
+                    break
+                lines.append(line)
+    except Exception as exc:
+        raise RuntimeError(f"Ошибка чтения файла: {exc}")
+    return "".join(lines).strip()
+
+
+def _image_preview(path: Path) -> str:
+    try:
+        with Image.open(path) as img:
+            text = pytesseract.image_to_string(img)
+    except Exception as exc:
+        raise RuntimeError(f"Ошибка OCR: {exc}")
+    return text.strip()
+
+
+SUPPORTED_IMAGES = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp"}
+SUPPORTED_TEXT = {".txt", ".csv"}
+SUPPORTED_DOCS = {".docx", ".doc"}
+
+
+def extract_preview_text(path: Path) -> str:
+    ext = path.suffix.lower()
+    try:
+        if ext == ".pdf":
+            return _pdf_preview(path)
+        if ext in SUPPORTED_DOCS:
+            return _docx_preview(path)
+        if ext in SUPPORTED_TEXT:
+            return _text_preview(path)
+        if ext in SUPPORTED_IMAGES:
+            return _image_preview(path)
+    except Exception as exc:
+        raise RuntimeError(str(exc))
+    raise RuntimeError("Просмотр не поддерживается")


### PR DESCRIPTION
## Summary
- support previewing various file formats using new `FilePreviewWorker`
- extract preview text from PDF/DOCX/TXT/CSV and images via `pytesseract`
- show preview in right pane when a row is selected
- improve metadata extraction to return explicit error messages and unsupported format info

## Testing
- `pytest -q`
- `python -m py_compile src/services/file_preview.py src/services/file_metadata.py src/gui/workers.py src/ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_683c13cdfd7883329c7a31c88dce8f7a