### PR TITLE
Improve UI error handling

### DIFF
--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -79,6 +79,7 @@ class FileMetadataWorker(QThread):
     """Worker thread for extracting metadata from files."""
 
     result = pyqtSignal(str, str, str, str)  # path, language, paper, pages/lines
+    error = pyqtSignal(str, str)  # path, error message
 
     def __init__(self, files: list[str]):
         super().__init__()
@@ -87,6 +88,8 @@ class FileMetadataWorker(QThread):
     def run(self) -> None:
         for path in self.files:
             count, language, paper = extract_metadata(Path(path))
+            if count.startswith("Ошибка") or count == "Неподдерживаемый формат":
+                self.error.emit(path, count)
             self.result.emit(path, language, paper, count)
 
 


### PR DESCRIPTION
## Summary
- emit metadata extraction errors from worker
- highlight table rows on metadata/preview errors with tooltips

## Testing
- `python -m py_compile src/gui/workers.py src/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_683c15d5dbb08332b0f8ce0f1f4b71d1