### PR TITLE
Implement file upload button

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -36,7 +36,6 @@ from gui.workers import (
 )
 
 
-
 class MainWindow(QMainWindow):
     """Главное окно приложения."""
 
@@ -112,6 +111,8 @@ class MainWindow(QMainWindow):
         self._row_map: dict[str, int] = {}
         # mapping from file path to processing error message
         self._error_map: dict[str, str] = {}
+        # set of all added file paths to prevent duplicates
+        self._all_paths: set[str] = set()
 
         # Нижняя панель кнопок
         bottom_panel = QHBoxLayout()
@@ -134,7 +135,6 @@ class MainWindow(QMainWindow):
 
         # Соединяем кнопки с заглушками
         for btn in (
-            self.loadFilesButton,
             self.clearBufferButton,
             self.runVerificationButton,
             self.viewLogsButton,
@@ -149,9 +149,49 @@ class MainWindow(QMainWindow):
             btn.clicked.connect(self._not_implemented)
 
         self.loadArchiveButton.clicked.connect(self.load_archive)
+        self.loadFilesButton.clicked.connect(self.load_files)
 
         self.fileTable.itemSelectionChanged.connect(self._preview_selected)
 
+    def load_files(self) -> None:
+        """Open file dialog and add selected files to the table."""
+        files, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Выберите файлы",
+            str(Path.home()),
+            "Все файлы (*)",
+        )
+        if not files:
+            return
+
+        new_files: list[str] = []
+        for f in files:
+            abs_path = str(Path(f).resolve())
+            if abs_path in self._all_paths:
+                continue
+            row = self.fileTable.rowCount()
+            self.fileTable.insertRow(row)
+            path_obj = Path(abs_path)
+            name_item = QTableWidgetItem(path_obj.name)
+            name_item.setData(Qt.ItemDataRole.UserRole, abs_path)
+            self.fileTable.setItem(row, 0, name_item)
+            self.fileTable.setItem(
+                row, 1, QTableWidgetItem(path_obj.suffix.lstrip("."))
+            )
+            self.fileTable.setItem(row, 2, QTableWidgetItem("-"))
+            self.fileTable.setItem(row, 3, QTableWidgetItem("-"))
+            self.fileTable.setItem(row, 4, QTableWidgetItem("-"))
+            self._row_map[abs_path] = row
+            self._all_paths.add(abs_path)
+            new_files.append(abs_path)
+
+        if not new_files:
+            return
+
+        self.meta_worker = FileMetadataWorker(new_files)
+        self.meta_worker.result.connect(self._update_metadata_row)
+        self.meta_worker.error.connect(self._on_meta_error)
+        self.meta_worker.start()
 
     def _preview_selected(self) -> None:
         selected = self.fileTable.selectedItems()
@@ -200,33 +240,40 @@ class MainWindow(QMainWindow):
         self.archive_worker.start()
 
     def on_archive_extracted(self, files: list[str]) -> None:
-        self._row_map.clear()
+        new_files: list[str] = []
         for file_path in files:
+            abs_path = str(Path(file_path).resolve())
+            if abs_path in self._all_paths:
+                continue
             row = self.fileTable.rowCount()
             self.fileTable.insertRow(row)
-            path = Path(file_path)
+            path = Path(abs_path)
             name_item = QTableWidgetItem(path.name)
-            name_item.setData(Qt.ItemDataRole.UserRole, str(path))
+            name_item.setData(Qt.ItemDataRole.UserRole, abs_path)
             self.fileTable.setItem(row, 0, name_item)
             self.fileTable.setItem(row, 1, QTableWidgetItem(path.suffix.lstrip(".")))
             self.fileTable.setItem(row, 2, QTableWidgetItem("-"))
             self.fileTable.setItem(row, 3, QTableWidgetItem("-"))
             self.fileTable.setItem(row, 4, QTableWidgetItem("-"))
-            self._row_map[str(path)] = row
+            self._row_map[abs_path] = row
+            self._all_paths.add(abs_path)
+            new_files.append(abs_path)
 
-        # start metadata extraction in background
-        self._error_map.clear()
-        self.meta_worker = FileMetadataWorker(files)
-        self.meta_worker.result.connect(self._update_metadata_row)
-        self.meta_worker.error.connect(self._on_meta_error)
-        self.meta_worker.start()
+        if new_files:
+            # start metadata extraction in background
+            self.meta_worker = FileMetadataWorker(new_files)
+            self.meta_worker.result.connect(self._update_metadata_row)
+            self.meta_worker.error.connect(self._on_meta_error)
+            self.meta_worker.start()
 
         QMessageBox.information(self, "Успех", "Архив успешно загружен")
 
     def on_archive_error(self, message: str) -> None:
         QMessageBox.critical(self, "Ошибка", message)
 
-    def _update_metadata_row(self, path: str, language: str, paper: str, count: str) -> None:
+    def _update_metadata_row(
+        self, path: str, language: str, paper: str, count: str
+    ) -> None:
         row = self._row_map.get(path)
         if row is None:
             return


### PR DESCRIPTION
## Summary
- add set for tracking uploaded files
- implement a new `load_files` handler
- prevent duplicates when adding files
- keep archive extraction compatible with the same logic
- connect the new button

## Testing
- `black --check src/ui/main_window.py`
- `python -m py_compile src/ui/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c1ae98a3883328bd187aaf8fe7383