### PR TITLE
Improve PDF extraction with OCR fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 # Основные зависимости
 PyQt6>=6.4.0
 PyPDF2>=3.0.0
+pdfminer.six>=20221105
+PyMuPDF>=1.21.1
 python-docx>=0.8.11
 Pillow>=9.0.0
 pytesseract>=0.3.10

--- a/src/services/file_preview.py
+++ b/src/services/file_preview.py
@@ -3,21 +3,77 @@ from __future__ import annotations
 from pathlib import Path
 
 from PyPDF2 import PdfReader
+from pdfminer.high_level import extract_text as pdfminer_extract_text
 from docx import Document
 from PIL import Image
 import pytesseract
+import fitz
+from io import BytesIO
+
+from config import PDF_IMAGE_DPI
 
 
 def _pdf_preview(path: Path) -> str:
-    reader = PdfReader(str(path))
-    text = ""
-    for page in reader.pages[:2]:
-        t = page.extract_text() or ""
-        text += t
-        if len(text) >= 2000:
-            text = text[:2000]
-            break
-    return text.strip()
+    """Return text preview for PDF using several fallbacks.
+
+    The function tries multiple extraction methods in the following order:
+    1. ``PyPDF2`` text layer extraction for the first few pages.
+    2. ``pdfminer.six`` extraction if PyPDF2 returned no text.
+    3. ``PyMuPDF`` OCR for scanned pages using ``pytesseract``.
+
+    Raises ``RuntimeError`` if no text could be extracted.
+    """
+
+    PAGE_LIMIT = 3
+    MAX_CHARS = 2000
+
+    last_error = ""
+
+    # --- Try PyPDF2 ------------------------------------------------------
+    try:
+        reader = PdfReader(str(path))
+        text = ""
+        for page in reader.pages[:PAGE_LIMIT]:
+            t = page.extract_text() or ""
+            text += t
+            if len(text) >= MAX_CHARS:
+                text = text[:MAX_CHARS]
+                break
+        if text.strip():
+            return text.strip()
+        last_error = "PyPDF2 не нашёл текст"
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        last_error = f"Ошибка PyPDF2: {exc}"
+
+    # --- Try pdfminer ----------------------------------------------------
+    try:
+        text = pdfminer_extract_text(str(path), page_numbers=range(PAGE_LIMIT)) or ""
+        text = text[:MAX_CHARS]
+        if text.strip():
+            return text.strip()
+        last_error = "pdfminer не нашёл текст"
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        last_error = f"Ошибка pdfminer: {exc}"
+
+    # --- OCR fallback using PyMuPDF + pytesseract -----------------------
+    try:
+        doc = fitz.open(str(path))
+        text = ""
+        for page in doc[:PAGE_LIMIT]:
+            pix = page.get_pixmap(dpi=PDF_IMAGE_DPI)
+            img = Image.open(BytesIO(pix.tobytes()))
+            text += pytesseract.image_to_string(img, lang="rus+eng") + "\n"
+            if len(text) >= MAX_CHARS:
+                text = text[:MAX_CHARS]
+                break
+        doc.close()
+        if text.strip():
+            return text.strip()
+        last_error = "Не удалось извлечь текст из скана"
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        last_error = f"Ошибка OCR: {exc}"
+
+    raise RuntimeError(last_error)
 
 
 def _docx_preview(path: Path) -> str:


### PR DESCRIPTION
## Summary
- support pdfminer.six and PyMuPDF for reliable PDF text extraction
- add OCR fallback using PyMuPDF and pytesseract
- update requirements with new dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c1e2022c48332b98511d4e4b0b417