### PR TITLE
Improve table extraction with OpenCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Python 3.11+
 - PyQt6
 - Дополнительные зависимости указаны в `requirements.txt`
-- Для улучшенного OCR потребуются `easyocr`, `paddleocr`, `camelot-py`, `pdfplumber` и `tabula-py`
+- Для улучшенного OCR потребуются `easyocr`, `paddleocr`, `camelot-py`, `pdfplumber`, `tabula-py` и `opencv-python`
 
 ## Установка
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ fuzzywuzzy>=0.18.0
 python-Levenshtein>=0.21.0
 pandas>=1.5.0
 reportlab>=3.6.0
+opencv-python>=4.5.0
 
 # Зависимости для разработки
 pytest>=7.0.0

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -10,7 +10,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor
+from PyQt6.QtGui import QColor, QPixmap
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
@@ -223,6 +223,7 @@ class MainWindow(QMainWindow):
         self.previewStack.setCurrentWidget(self.textPreview)
         self.preview_worker = FilePreviewWorker(path)
         self.preview_worker.finished.connect(self._on_preview_ready)
+        self.preview_worker.imageReady.connect(self._on_preview_image)
         self.preview_worker.error.connect(self._on_preview_error)
         self.preview_worker.start()
 
@@ -296,6 +297,18 @@ class MainWindow(QMainWindow):
     def _on_preview_ready(self, path: str, text: str) -> None:
         self.textPreview.setPlainText(text)
         self.previewStack.setCurrentWidget(self.textPreview)
+
+    def _on_preview_image(self, path: str, image_path: str) -> None:
+        pixmap = QPixmap(image_path)
+        self.imagePreview.setPixmap(
+            pixmap.scaled(
+                self.imagePreview.size(),
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        )
+        QMessageBox.warning(self, "OCR", "Не удалось корректно распознать таблицу")
+        self.previewStack.setCurrentWidget(self.imagePreview)
 
     def _on_preview_error(self, path: str, message: str) -> None:
         self.textPreview.setPlainText(message)


### PR DESCRIPTION
## Summary
- enhance OCR preprocessing with deskew and autocontrast
- fallback to OpenCV cell detection when Camelot/pdfplumber find no tables
- return preview image when OCR fails
- support preview image display in the UI
- add OpenCV dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683c2dee5eb48332a1df8c1a6948e3e3