### PR TITLE
Add quick preview & fuzzy verification

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,9 +14,9 @@ EXTRACTED_FILES_DIR.mkdir(exist_ok=True)
 
 # Настройки безопасности
 ALLOWED_EXTENSIONS: Dict[str, List[str]] = {
-    'archives': ['.zip', '.rar', '.7z'],
-    'documents': ['.pdf', '.docx', '.doc', '.txt', '.rtf'],
-    'images': ['.jpg', '.jpeg', '.png', '.tiff', '.bmp']
+    "archives": [".zip", ".rar", ".7z"],
+    "documents": [".pdf", ".docx", ".doc", ".txt", ".rtf"],
+    "images": [".jpg", ".jpeg", ".png", ".tiff", ".bmp"],
 }
 
 # Собираем все разрешенные расширения в один список
@@ -34,6 +34,11 @@ PDF_IMAGE_DPI = 300  # DPI для конвертации в изображени
 PDF_IMAGE_THRESHOLD = 128  # Порог бинаризации для OCR
 PDF_MAX_WORKERS = 4  # Максимальное количество потоков для обработки
 
+# Настройки быстрого извлечения
+PREVIEW_PAGE_COUNT = 2  # Количество страниц с начала и с конца для предпросмотра
+PREVIEW_PARAGRAPH_COUNT = 2  # Количество абзацев с начала и конца
+FUZZY_THRESHOLD = 70  # Порог схожести для fuzzy matching
+
 # Настройки обработки DOC/DOCX
 DOC_MAX_WORKERS = 4  # Максимальное количество потоков для обработки
 DOC_MIN_TEXT_LENGTH = 50  # Минимальная длина текста для проверки качества извлечения
@@ -46,29 +51,27 @@ LOG_LEVEL = logging.DEBUG  # Используем константу из мод
 
 # Конфигурация логирования
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            'format': LOG_FORMAT
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {"format": LOG_FORMAT},
+    },
+    "handlers": {
+        "console": {
+            "level": LOG_LEVEL,
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+        },
+        "file": {
+            "level": LOG_LEVEL,
+            "class": "logging.FileHandler",
+            "filename": str(LOG_FILE),
+            "formatter": "standard",
+            "encoding": "utf-8",
         },
     },
-    'handlers': {
-        'console': {
-            'level': LOG_LEVEL,
-            'class': 'logging.StreamHandler',
-            'formatter': 'standard',
-        },
-        'file': {
-            'level': LOG_LEVEL,
-            'class': 'logging.FileHandler',
-            'filename': str(LOG_FILE),
-            'formatter': 'standard',
-            'encoding': 'utf-8',
-        },
-    },
-    'root': {
-        'handlers': ['console', 'file'],
-        'level': LOG_LEVEL,
+    "root": {
+        "handlers": ["console", "file"],
+        "level": LOG_LEVEL,
     },
 }

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -7,6 +7,9 @@ from typing import List
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from fuzzywuzzy import process
+
+from constants import REFERENCE_NAMES
 
 import rarfile
 import py7zr
@@ -22,35 +25,35 @@ def extract_archive(archive_path: str, dest_dir: Path) -> List[str]:
     archive_lower = archive_path.lower()
     extracted: List[str] = []
 
-    if archive_lower.endswith('.zip'):
-        with zipfile.ZipFile(archive_path, 'r') as zf:
+    if archive_lower.endswith(".zip"):
+        with zipfile.ZipFile(archive_path, "r") as zf:
             for member in zf.infolist():
                 if member.is_dir():
                     continue
                 zf.extract(member, dest_dir)
                 extracted.append(str(dest_dir / member.filename))
-    elif archive_lower.endswith('.rar'):
+    elif archive_lower.endswith(".rar"):
         with rarfile.RarFile(archive_path) as rf:
             for member in rf.infolist():
                 if member.isdir():
                     continue
                 rf.extract(member, dest_dir)
                 extracted.append(str(dest_dir / member.filename))
-    elif archive_lower.endswith('.7z'):
-        with py7zr.SevenZipFile(archive_path, mode='r') as sz:
+    elif archive_lower.endswith(".7z"):
+        with py7zr.SevenZipFile(archive_path, mode="r") as sz:
             sz.extractall(path=dest_dir)
             for name in sz.getnames():
-                if not name.endswith('/'):
+                if not name.endswith("/"):
                     extracted.append(str(dest_dir / name))
-    elif archive_lower.endswith(('.tar', '.tar.gz', '.tgz', '.tar.bz2', '.tbz2')):
-        with tarfile.open(archive_path, 'r:*') as tf:
+    elif archive_lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+        with tarfile.open(archive_path, "r:*") as tf:
             for member in tf.getmembers():
                 if member.isdir():
                     continue
                 tf.extract(member, dest_dir)
                 extracted.append(str(dest_dir / member.name))
     else:
-        raise ValueError('Неподдерживаемый формат архива')
+        raise ValueError("Неподдерживаемый формат архива")
 
     return extracted
 
@@ -142,3 +145,64 @@ class FilePreviewWorker(QThread):
                 self.error.emit(self.path, "Не удалось создать превью")
         except Exception as exc:
             self.error.emit(self.path, str(exc))
+
+
+class QuickPreviewWorker(QThread):
+    """Extract preview text for a batch of files."""
+
+    finished = pyqtSignal(str, str)  # path, text
+    error = pyqtSignal(str, str)
+
+    def __init__(self, files: list[str]):
+        super().__init__()
+        self.files = files
+
+    def run(self) -> None:
+        with ThreadPoolExecutor(max_workers=4) as ex:
+            future_map = {
+                ex.submit(extract_preview_text, Path(p)): p for p in self.files
+            }
+            for fut in as_completed(future_map):
+                path = future_map[fut]
+                try:
+                    text = fut.result()
+                    self.finished.emit(path, text)
+                except Exception as exc:
+                    self.error.emit(path, str(exc))
+
+
+class VerificationWorker(QThread):
+    """Run fuzzy verification against reference names."""
+
+    result = pyqtSignal(str, str, str, str, int)  # path, line, ref, number, score
+    finished = pyqtSignal()
+
+    def __init__(self, data: dict[str, str], threshold: int):
+        super().__init__()
+        self.data = data
+        self.threshold = threshold
+
+    def run(self) -> None:
+        from fuzzywuzzy import fuzz
+        import re
+
+        references = [r["ru"] for r in REFERENCE_NAMES]
+        for path, text in self.data.items():
+            best_line = ""
+            best_ref = ""
+            best_score = 0
+            for line in text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                ref, score = process.extractOne(
+                    line, references, scorer=fuzz.token_set_ratio
+                )
+                if score > best_score:
+                    best_score = score
+                    best_line = line
+                    best_ref = ref
+            num_match = re.search(r"№\s*\S+", text)
+            number = num_match.group(0) if num_match else ""
+            self.result.emit(path, best_line, best_ref, number, best_score)
+        self.finished.emit()


### PR DESCRIPTION
## Summary
- add constants for quick preview and matching threshold
- implement batch preview and verification workers
- enhance preview logic with quick extraction and result display
- update PDF/Docx/Text preview to use first/last pages/paragraphs

## Testing
- `pytest -q`
- `python -m py_compile src/gui/workers.py src/services/file_preview.py src/ui/main_window.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_683c4b23fc6c833286829ae75c133f97