### PR TITLE
Fix tuple unpacking to avoid errors

### DIFF
--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from rapidfuzz import process, fuzz
 
 from constants import REFERENCE_NAMES
+from utils import unpack3
 
 import rarfile
 import py7zr
@@ -103,7 +104,8 @@ class FileMetadataWorker(QThread):
                 path = future_map[fut]
                 duration = time.perf_counter() - start_times[fut]
                 try:
-                    count, language, paper = fut.result()
+                    result = fut.result()
+                    count, language, paper = unpack3(result)
                     if duration > 5:
                         logging.getLogger(__name__).warning(
                             "Metadata extraction for %s took %.2f sec", path, duration
@@ -129,7 +131,8 @@ class FilePreviewWorker(QThread):
     def run(self) -> None:
         start = time.perf_counter()
         try:
-            text, image, err = extract_preview(Path(self.path))
+            result = extract_preview(Path(self.path))
+            text, image, err = unpack3(result)
             duration = time.perf_counter() - start
             if duration > 5:
                 logging.getLogger(__name__).warning(

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -19,3 +19,13 @@ def fix_row(row: Iterable[Any] | None, length: int, default: Any = "") -> List[A
     except Exception as exc:  # pragma: no cover - unexpected errors
         logging.getLogger(__name__).error("fix_row error: %s", exc)
         return [default for _ in range(length)]
+
+
+def unpack3(row: Iterable[Any] | None, default: Any = "") -> tuple[Any, Any, Any]:
+    """Return exactly three values from ``row``.
+
+    Missing items are replaced with ``default`` and extra items are discarded.
+    Any unexpected errors are logged and ``default`` values are returned.
+    """
+    fixed = fix_row(row, 3, default)
+    return tuple(fixed[:3])  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- add utility `unpack3` to safely unpack up to three values
- use `unpack3` when handling results in workers
- apply `unpack3` in PDF preview helper functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683c544aa424833299b7af4352d6a27f