### PR TITLE
Enable logging across application

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ LOG_FILE = BASE_DIR / "application_logs.txt"
 # Создаем необходимые директории
 TEMP_DIR.mkdir(exist_ok=True)
 EXTRACTED_FILES_DIR.mkdir(exist_ok=True)
+LOG_FILE.parent.mkdir(exist_ok=True)
 
 # Настройки безопасности
 ALLOWED_EXTENSIONS: Dict[str, List[str]] = {
@@ -47,7 +48,7 @@ DOC_IMAGE_THRESHOLD = 128  # Порог бинаризации для OCR
 
 # Настройки логирования
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
-LOG_LEVEL = logging.DEBUG  # Используем константу из модуля logging
+LOG_LEVEL = logging.INFO  # базовый уровень логирования
 
 # Конфигурация логирования
 LOGGING = {

--- a/refactored_main.py
+++ b/refactored_main.py
@@ -4,17 +4,15 @@ import logging.config
 from pathlib import Path
 from PyQt6.QtWidgets import QApplication
 from src.ui.main_window import MainWindow
-from config import LOGGING
+from config import LOGGING, LOG_FILE
 
 # Настройка логирования
 def setup_logging():
     # Создаем директорию для логов, если она не существует
-    log_dir = Path("logs")
-    log_dir.mkdir(parents=True, exist_ok=True)
-    
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
     # Обновляем путь к файлу логов в конфигурации
-    log_file = log_dir / "application.log"
-    LOGGING['handlers']['file']['filename'] = str(log_file)
+    LOGGING['handlers']['file']['filename'] = str(LOG_FILE)
     
     # Применяем конфигурацию
     logging.config.dictConfig(LOGGING)


### PR DESCRIPTION
## Summary
- enable INFO level logging with log file configured
- write logs for metadata extraction, preview creation, verification and more
- show log viewer dialog in GUI
- make loggers record stack traces on errors

## Testing
- `python -m py_compile refactored_main.py src/gui/workers.py src/ui/main_window.py src/services/document_workflow.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c5c16e8d483328c37e93ed2e6231b