### PR TITLE
Improve logging and log viewer

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Initialization for src package."""
+
+import logging
+import logging.config
+
+try:  # pragma: no cover - no need to test
+    from config import LOGGING
+    logging.config.dictConfig(LOGGING)
+except Exception:  # pragma: no cover - if config missing
+    logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- configure logging when importing `src`
- add `LogDialog` for displaying logs
- extend logging of user actions in main window
- keep logs available even when empty or missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c7982ed6c833281425a6082593bfe