### PR TITLE
Add logging system and viewer

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,7 +41,8 @@ DOC_IMAGE_DPI = 300  # DPI для конвертации в изображени
 DOC_IMAGE_THRESHOLD = 128  # Порог бинаризации для OCR
 
 # Настройки логирования
-LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+LOG_FORMAT = "[%(asctime)s][%(levelname)s] %(message)s"
+LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
 LOG_LEVEL = logging.DEBUG  # Используем константу из модуля logging
 
 # Конфигурация логирования
@@ -50,7 +51,8 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'standard': {
-            'format': LOG_FORMAT
+            'format': LOG_FORMAT,
+            'datefmt': LOG_DATEFMT,
         },
     },
     'handlers': {

--- a/refactored_main.py
+++ b/refactored_main.py
@@ -4,18 +4,13 @@ import logging.config
 from pathlib import Path
 from PyQt6.QtWidgets import QApplication
 from src.ui.main_window import MainWindow
-from config import LOGGING
+from config import LOGGING, LOG_FILE
 
 # Настройка логирования
 def setup_logging():
-    # Создаем директорию для логов, если она не существует
-    log_dir = Path("logs")
-    log_dir.mkdir(parents=True, exist_ok=True)
-    
-    # Обновляем путь к файлу логов в конфигурации
-    log_file = log_dir / "application.log"
-    LOGGING['handlers']['file']['filename'] = str(log_file)
-    
+    """Configure application logging."""
+    LOGGING['handlers']['file']['filename'] = str(LOG_FILE)
+
     # Применяем конфигурацию
     logging.config.dictConfig(LOGGING)
     logger = logging.getLogger(__name__)
@@ -27,21 +22,25 @@ def main():
         # Настройка логирования
         setup_logging()
         logger = logging.getLogger(__name__)
+        logger.info("Приложение запущено")
         
         # Создание приложения
         app = QApplication(sys.argv)
         
         # Создание и отображение главного окна
+        logger.info("Запуск главного окна приложения")
         window = MainWindow()
         window.show()
         
         # Запуск цикла обработки событий
-        sys.exit(app.exec())
+        exit_code = app.exec()
+        logger.info("Приложение завершилось с кодом %s", exit_code)
+        sys.exit(exit_code)
         
     except Exception as e:
         # Если логгер еще не настроен, выводим ошибку в консоль
         try:
-            logger.critical(f"Критическая ошибка: {str(e)}")
+            logger.exception("Критическая ошибка: %s", e)
         except:
             print(f"Критическая ошибка: {str(e)}")
         sys.exit(1)

--- a/src/ui/log_viewer.py
+++ b/src/ui/log_viewer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import logging
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QTextEdit,
+    QPushButton,
+    QHBoxLayout,
+    QMessageBox,
+    QFileDialog,
+)
+from PyQt6.QtGui import QTextCursor
+
+logger = logging.getLogger(__name__)
+
+
+class LogViewerDialog(QDialog):
+    """Диалоговое окно просмотра логов."""
+
+    def __init__(self, log_file: Path, parent=None, max_lines: int = 200) -> None:
+        super().__init__(parent)
+        self.log_file = log_file
+        self.max_lines = max_lines
+        self.setWindowTitle("Логи")
+        self.resize(800, 600)
+
+        layout = QVBoxLayout(self)
+        self.text = QTextEdit()
+        self.text.setReadOnly(True)
+        self.text.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
+        layout.addWidget(self.text)
+
+        btn_layout = QHBoxLayout()
+        self.refreshButton = QPushButton("Обновить")
+        self.saveButton = QPushButton("Сохранить как файл")
+        btn_layout.addWidget(self.refreshButton)
+        btn_layout.addWidget(self.saveButton)
+        btn_layout.addStretch()
+        layout.addLayout(btn_layout)
+
+        self.refreshButton.clicked.connect(self.load_logs)
+        self.saveButton.clicked.connect(self.save_logs)
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
+        self.load_logs()
+
+    def _append_colored(self, line: str) -> None:
+        color = "black"
+        if "[ERROR]" in line:
+            color = "red"
+        elif "[WARNING]" in line:
+            color = "orange"
+        self.text.append(f'<span style="color:{color}">{line}</span>')
+
+    def load_logs(self) -> None:
+        """Load last N lines from log file."""
+        try:
+            if not self.log_file.exists():
+                self.text.clear()
+                QMessageBox.information(self, "Логи", "Файл логов отсутствует")
+                return
+            lines = self.log_file.read_text(encoding="utf-8", errors="ignore").splitlines()
+            lines = lines[-self.max_lines :]
+            self.text.clear()
+            for line in lines:
+                self._append_colored(line)
+            self.text.moveCursor(QTextCursor.MoveOperation.End)
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.exception("Ошибка чтения логов: %s", exc)
+            QMessageBox.critical(self, "Ошибка", f"Не удалось загрузить логи: {exc}")
+
+    def save_logs(self) -> None:
+        """Save current log file to user selected location."""
+        try:
+            if not self.log_file.exists():
+                QMessageBox.information(self, "Логи", "Файл логов отсутствует")
+                return
+            dest_path, _ = QFileDialog.getSaveFileName(
+                self,
+                "Сохранить лог",
+                str(Path.home() / "application_logs.txt"),
+                "Text Files (*.txt);;All Files (*)",
+            )
+            if dest_path:
+                shutil.copy(str(self.log_file), dest_path)
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.exception("Ошибка сохранения логов: %s", exc)
+            QMessageBox.critical(self, "Ошибка", f"Не удалось сохранить логи: {exc}")


### PR DESCRIPTION
## Summary
- implement improved logging configuration
- add log viewer dialog with colored levels
- log application workflow and errors across modules
- integrate logging into GUI and services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c8ddc327c8332b01028c819010d0c