### PR TITLE
Fix safe worker removal

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -177,7 +177,15 @@ class MainWindow(QMainWindow):
     def _start_worker(self, worker: QThread) -> None:
         """Start and track a QThread worker."""
         self._workers.append(worker)
-        worker.finished.connect(lambda w=worker: self._workers.remove(w))
+
+        def _cleanup(w=worker) -> None:
+            try:
+                self._workers.remove(w)
+            except ValueError:
+                pass
+
+        worker.finished.connect(_cleanup)
+        worker.terminated.connect(_cleanup)
         worker.start()
 
     def load_files(self) -> None:


### PR DESCRIPTION
## Summary
- safely remove threads from `_workers` list when finished
- handle finished and terminated signals with a single cleanup handler

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca709ab3c8332905e460323db10db