### PR TITLE
Fix worker cleanup signal

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -185,7 +185,6 @@ class MainWindow(QMainWindow):
                 pass
 
         worker.finished.connect(_cleanup)
-        worker.terminated.connect(_cleanup)
         worker.start()
 
     def load_files(self) -> None:


### PR DESCRIPTION
## Summary
- remove connection to nonexistent `terminated` signal
- rely on QThread `finished` signal for cleanup

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cab6f9dd883328519d4bd28fada5f