### PR TITLE
Improve logging setup

### DIFF
--- a/refactored_main.py
+++ b/refactored_main.py
@@ -3,6 +3,17 @@ import logging
 import logging.config
 import os
 from pathlib import Path
+
+# Базовая конфигурация логирования до импортов PyQt
+LOG_FILE_PATH = Path(__file__).resolve().parent / "application_logs.txt"
+logging.basicConfig(
+    filename=str(LOG_FILE_PATH),
+    level=logging.INFO,
+    format="[%(asctime)s][%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logging.info("Базовая конфигурация логирования инициализирована")
+
 from PyQt6.QtWidgets import QApplication
 from src.ui.main_window import MainWindow
 from config import LOGGING, LOG_FILE

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -386,7 +386,6 @@ class MainWindow(QMainWindow):
         self.textPreview.clear()
         self.imagePreview.clear()
         self.previewStack.setCurrentWidget(self.unsupportedLabel)
-        self.logger.info("Файл %s удален", path)
         self.logger.info("Буфер очищен")
 
     def _show_file_menu(self, pos) -> None:


### PR DESCRIPTION
## Summary
- configure `logging.basicConfig` at the top of the entrypoint so the log file
  is created before importing PyQt
- remove an undefined variable log line in `clear_buffer`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683cb20ad61c8332972a2a831d3f66cc