### PR TITLE
perf: preview only first page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ pip install -r requirements.txt
 python refactored_main.py
 ```
 
+## Testing
+
+Быстрая проверка выполняется командами:
+
+```bash
+time python -m py_compile $(git ls-files '*.py')
+python benchmarks/profile_preview.py sample_dir/
+```
+
+Превью отображает только первую страницу документа ради производительности.
+
 ## Структура проекта
 
 ```

--- a/benchmarks/profile_preview.py
+++ b/benchmarks/profile_preview.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+import time
+from services.file_preview import extract_preview_text
+
+
+def main(dir_path: str) -> None:
+    start = time.perf_counter()
+    count = 0
+    for p in Path(dir_path).glob('*'):
+        if p.is_file():
+            try:
+                extract_preview_text(p)
+            except Exception:
+                pass
+            count += 1
+    duration = time.perf_counter() - start
+    print(f"Processed {count} files in {duration:.2f}s")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: profile_preview.py DIR")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -127,15 +127,17 @@ class FilePreviewWorker(QThread):
 
     def run(self) -> None:
         try:
-            logger.info("Извлечение превью для %s", self.path)
-            text, image = extract_preview(Path(self.path))
+            logger.info(
+                "Preview first page only for %s", Path(self.path).name
+            )
+            text, image, err = extract_preview(Path(self.path))
             if image:
                 self.imageReady.emit(self.path, image)
             if text:
                 self.finished.emit(self.path, text)
-            elif not image:
+            elif err:
                 logger.warning("Не удалось создать превью для %s", self.path)
-                self.error.emit(self.path, "Не удалось создать превью")
+                self.error.emit(self.path, err)
             logger.info("Превью успешно создано для %s", self.path)
         except Exception as exc:
             logger.exception("Ошибка создания превью %s", self.path)


### PR DESCRIPTION
## Summary
- limit preview extraction to the first page of documents
- update GUI worker to log and emit new preview tuple
- add small benchmark helper
- document testing steps and first-page optimisation

## Testing
- `time python -m py_compile $(git ls-files '*.py')`
- `python benchmarks/profile_preview.py sample_dir/` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_683dfc710518833289c758f3caea566d