### PR TITLE
Fix log flushing

### DIFF
--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -2,13 +2,11 @@ import logging
 
 
 def logger_flush() -> None:
-    """Flush and close handlers of the root logger if needed."""
+    """Flush handlers of the root logger."""
     root_logger = logging.getLogger()
     for handler in list(root_logger.handlers):
         try:
             if hasattr(handler, "flush"):
                 handler.flush()
-            if hasattr(handler, "close"):
-                handler.close()
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- avoid closing log handlers when refreshing logs

## Testing
- `time python -m py_compile $(git ls-files '*.py')`
- `python benchmarks/profile_preview.py sample_dir/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed2ff8d883329d399fbd4108ec62